### PR TITLE
Use useTick instead of setInterval in devtools demo

### DIFF
--- a/examples/devtools-demo.tsx
+++ b/examples/devtools-demo.tsx
@@ -20,8 +20,8 @@ import {
   Spinner,
   useInput,
   useTui,
-  useCleanup,
   enableDevTools,
+  useTick,
 } from "../src/index.js";
 
 // ── Sample components ───────────────────────────────────────────────
@@ -29,45 +29,60 @@ import {
 function Clock() {
   const { requestRender } = useTui();
   const textRef = React.useRef<any>(null);
-  const timerRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
 
-  if (!timerRef.current) {
-    timerRef.current = setInterval(() => {
+  useTick(
+    1000,
+    () => {
       const t = new Date().toLocaleTimeString();
       if (textRef.current && textRef.current.text !== t) {
         textRef.current.text = t;
         requestRender();
       }
-    }, 1000);
-  }
-  useCleanup(() => { if (timerRef.current) clearInterval(timerRef.current); });
+    },
+    { reactive: false }
+  );
 
-  return React.createElement("tui-text", {
-    color: "#82AAFF", bold: true, _textNodeRef: textRef,
-  }, new Date().toLocaleTimeString());
+  return React.createElement(
+    "tui-text",
+    { color: "#82AAFF", bold: true, _textNodeRef: textRef },
+    new Date().toLocaleTimeString()
+  );
 }
 
 function Counter() {
   const [count, setCount] = useState(0);
-  const timerRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
 
-  if (!timerRef.current) {
-    timerRef.current = setInterval(() => setCount(c => c + 1), 2000);
-  }
-  useCleanup(() => { if (timerRef.current) clearInterval(timerRef.current); });
+  useTick(2000, () => {
+    setCount((c) => c + 1);
+  });
 
   return (
     <Box flexDirection="row" gap={1}>
       <Text dim>Counter:</Text>
-      <Text color="#FFB800" bold>{String(count)}</Text>
+      <Text color="#FFB800" bold>
+        {String(count)}
+      </Text>
     </Box>
   );
 }
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+function Panel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
-    <Box flexDirection="column" borderStyle="single" borderColor="#333333" paddingX={1}>
-      <Text bold color="#82AAFF">{title}</Text>
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="#333333"
+      paddingX={1}
+    >
+      <Text bold color="#82AAFF">
+        {title}
+      </Text>
       {children}
     </Box>
   );
@@ -75,22 +90,35 @@ function Panel({ title, children }: { title: string; children: React.ReactNode }
 
 function App() {
   const { exit } = useTui();
-  useInput((e) => { if (e.key === "c" && e.ctrl) exit(); });
+
+  useInput((e) => {
+    if (e.key === "c" && e.ctrl) exit();
+  });
 
   return (
     <Box flexDirection="column" padding={1}>
-      <Text bold color="#82AAFF">{"  Storm TUI DevTools Demo"}</Text>
-      <Text dim>{"  Press 1-4 to toggle features. App keeps running underneath.\n"}</Text>
+      <Text bold color="#82AAFF">
+        {"  Storm TUI DevTools Demo"}
+      </Text>
+      <Text dim>
+        {"  Press 1-4 to toggle features. App keeps running underneath.\n"}
+      </Text>
 
       <Box flexDirection="row" gap={1}>
-        <Panel title="Live Clock"><Clock /></Panel>
+        <Panel title="Live Clock">
+          <Clock />
+        </Panel>
+
         <Panel title="Spinner">
           <Box flexDirection="row" gap={1}>
             <Spinner type="dots" />
             <Text>Processing...</Text>
           </Box>
         </Panel>
-        <Panel title="Counter"><Counter /></Panel>
+
+        <Panel title="Counter">
+          <Counter />
+        </Panel>
       </Box>
 
       <Box marginTop={1}>
@@ -102,15 +130,21 @@ function App() {
 
       <Box marginTop={1}>
         <Panel title="Contrast Test">
-          <Text color="#333333">Dark gray on black — should FAIL a11y audit</Text>
+          <Text color="#333333">
+            Dark gray on black — should FAIL a11y audit
+          </Text>
           <Text color="#FFFFFF">White on black — should PASS</Text>
-          <Text color="#82AAFF" bold>Brand blue on black — check the ratio</Text>
+          <Text color="#82AAFF" bold>
+            Brand blue on black — check the ratio
+          </Text>
         </Panel>
       </Box>
 
       <Box marginTop={1} paddingX={1}>
         <Text dim color="#555555">
-          {"1:Heatmap  2:A11y  3:Time-Travel(←→)  4:DevTools([]:panels jk:nav space:toggle)  Ctrl+C:exit"}
+          {
+            "1:Heatmap  2:A11y  3:Time-Travel(←→)  4:DevTools([]:panels jk:nav space:toggle)  Ctrl+C:exit"
+          }
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
## What changed
- Replaced `setInterval` with `useTick` in the devtools demo clock and counter.
- Did some small JSX formatting tweaks.

## Why
- `useTick` is the recommended timer API in this library.
- Cleans up manual interval setup and cleanup.

## Checklist

- [x] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes
- [ ] New exports added to `src/index.ts`
- [ ] Documentation updated in `docs/`
Note: 'npx vitest run' fails locally only on performance benchmark tests in src/__tests__/benchmarks.test.ts (time thresholds). Functional tests are passing.
